### PR TITLE
fix: added if on allure link before put error

### DIFF
--- a/error-handler.sh
+++ b/error-handler.sh
@@ -53,8 +53,12 @@ finalize_once() {
       EXECUTION_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
       export TIMESTAMP
       TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S UTC')"
-      export ALLURE_REPORT_URL="Test not started. Please check the logs for more details. $FAIL_MESSAGE. "
-      export ATP_REPORT_VIEW_UI_URL="Test not started. Please check the logs for more details. $FAIL_MESSAGE. "
+      if compgen -G "$TMP_DIR/allure-results/*-result.json" > /dev/null 2>&1; then
+        echo "ℹ️  Allure results detected — skipping 'Test not started' URL override."
+      else
+        export ALLURE_REPORT_URL="Test not started. Please check the logs for more details. $FAIL_MESSAGE. "
+        export ATP_REPORT_VIEW_UI_URL="Test not started. Please check the logs for more details. $FAIL_MESSAGE. "
+      fi
     fi
 
     generate_email_notification_json || true


### PR DESCRIPTION
To avoid cases when error-handler is triggered with existing allure test results , addresses this issue https://github.com/Netcracker/qubership-testing-platform-playwright-runner/issues/34
<!-- start messages -->
### Commit messages:
[callmesi](https://github.com/Netcracker/qubership-testing-platform-common-scripts/commit/d6894b6d2c2fd3a4d68bed96cb3e857292badb61) fix: added if on allure link before put error
<!-- end messages -->
