### PR TITLE
fix: use file instead of test_details json ENV

### DIFF
--- a/email-notification/README-email-notification-json.md
+++ b/email-notification/README-email-notification-json.md
@@ -63,7 +63,8 @@ The script uses the following environment variables for JSON generation:
 - `REPORT_VIEW_HOST_URL` - Host for viewing reports
 - `ALLURE_REPORT_URL` - Path to reports folder
 - `TIMESTAMP` - Timestamp
-- `TEST_DETAILS_STRING` - String with details of all tests (used during generation only; not exported — large runs would exceed ARG_MAX)
+- `TEST_DETAILS_FILE` - Path to text file with test details (for email templates; avoids ARG_MAX on large runs)
+- `TEST_DETAILS_STRING` - **Deprecated.** Legacy fallback only; do not use on large runs
 
 ## Generated JSON Structure
 

--- a/email-notification/calculate-email-notification-variables.sh
+++ b/email-notification/calculate-email-notification-variables.sh
@@ -58,11 +58,14 @@ passed_tests=0
 failed_tests=0
 skipped_tests=0
 
-# Initialize test details arrays
-declare -a test_details=()
-# Add table header
-test_details+=("$(printf "%-12s" "Status") | Test Name")
-test_details+=("------------ | ------------------------------------------------------------")
+# Stream test details to file (avoids ARG_MAX from giant in-memory strings)
+TEST_DETAILS_DIR="/tmp/clone/scripts/email-notification-generated"
+mkdir -p "$TEST_DETAILS_DIR"
+TEST_DETAILS_FILE="$TEST_DETAILS_DIR/test-details.txt"
+{
+    printf '%s | Test Name\n' "$(printf '%-12s' "Status")"
+    printf '%s\n' "------------ | ------------------------------------------------------------"
+} > "$TEST_DETAILS_FILE"
 
 # Process each result file
 for result_file in "$ALLURE_RESULTS_DIR"/*-result.json; do
@@ -78,21 +81,21 @@ for result_file in "$ALLURE_RESULTS_DIR"/*-result.json; do
             "passed")
                 passed_tests=$((passed_tests + 1))
                 log_success "✓ $test_name"
-                test_details+=("✅ PASSED | $test_name")
+                printf '%s\n' "✅ PASSED | $test_name" >> "$TEST_DETAILS_FILE"
                 ;;
             "failed")
                 failed_tests=$((failed_tests + 1))
                 log_error "✗ $test_name"
-                test_details+=("❌ FAILED | $test_name")
+                printf '%s\n' "❌ FAILED | $test_name" >> "$TEST_DETAILS_FILE"
                 ;;
             "skipped")
                 skipped_tests=$((skipped_tests + 1))
                 log_warning "⚠ $test_name"
-                test_details+=("⚠️ SKIPPED | $test_name")
+                printf '%s\n' "⚠️ SKIPPED | $test_name" >> "$TEST_DETAILS_FILE"
                 ;;
             *)
                 log_warning "? $test_name (status: $status)"
-                test_details+=("❓ UNKNOWN | $test_name")
+                printf '%s\n' "❓ UNKNOWN | $test_name" >> "$TEST_DETAILS_FILE"
                 ;;
         esac
         
@@ -136,15 +139,8 @@ export TEST_FAILED_COUNT="$failed_tests"
 export TEST_SKIPPED_COUNT="$skipped_tests"
 export TEST_OVERALL_STATUS="$overall_status"
 
-# Create test details string
-TEST_DETAILS_STRING=""
-for test_detail in "${test_details[@]}"; do
-    if [ -n "$TEST_DETAILS_STRING" ]; then
-        TEST_DETAILS_STRING="$TEST_DETAILS_STRING\n$test_detail"
-    else
-        TEST_DETAILS_STRING="$test_detail"
-    fi
-done
+export TEST_DETAILS_FILE
+unset TEST_DETAILS_STRING
 
 # Display summary
 echo ""
@@ -166,6 +162,6 @@ echo "TEST_PASSED_COUNT=$passed_tests"
 echo "TEST_FAILED_COUNT=$failed_tests"
 echo "TEST_SKIPPED_COUNT=$skipped_tests"
 echo "TEST_OVERALL_STATUS=$overall_status"
-echo "TEST_DETAILS_STRING=<multiline string with test details>"
+echo "TEST_DETAILS_FILE=$TEST_DETAILS_FILE"
 
 log_success "Pass rate calculation completed successfully"

--- a/email-notification/calculate-email-notification-variables.sh
+++ b/email-notification/calculate-email-notification-variables.sh
@@ -25,6 +25,7 @@ log_warning() {
 log_error() {
     echo "❌ $1"
 }
+
 # shellcheck disable=SC2034
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/email-notification/generate-email-notification-file.sh
+++ b/email-notification/generate-email-notification-file.sh
@@ -181,15 +181,14 @@ generate_email_notification_file() {
     }')
 
     # Replace TEST_DETAILS placeholder separately
-    if [ -n "${TEST_DETAILS_STRING:-}" ]; then
-        # Create temporary file with test details
+    if [ -n "${TEST_DETAILS_FILE:-}" ] && [ -f "$TEST_DETAILS_FILE" ]; then
+        temp_details_file="$TEST_DETAILS_FILE"
+        message_content=$(echo "$message_content" | sed "/{{TEST_DETAILS}}/r $temp_details_file" | sed "/{{TEST_DETAILS}}/d")
+    elif [ -n "${TEST_DETAILS_STRING:-}" ]; then
+        # legacy fallback for older callers
         temp_details_file=$(mktemp)
         echo -e "$TEST_DETAILS_STRING" > "$temp_details_file"
-        
-        # Use sed with file input to replace placeholder
         message_content=$(echo "$message_content" | sed "/{{TEST_DETAILS}}/r $temp_details_file" | sed "/{{TEST_DETAILS}}/d")
-        
-        # Clean up temporary file
         rm -f "$temp_details_file"
     else
         message_content=$(echo "$message_content" | sed "s|{{TEST_DETAILS}}|No test details available|g")

--- a/email-notification/generate-email-notification-json.sh
+++ b/email-notification/generate-email-notification-json.sh
@@ -28,6 +28,7 @@ generate_email_notification_json() {
     log_error() {
         echo "❌ $1"
     }
+
     # Get script directory
     local SCRIPT_DIR
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/email-notification/generate-email-notification-json.sh
+++ b/email-notification/generate-email-notification-json.sh
@@ -74,7 +74,8 @@ generate_email_notification_json() {
     local test_details_json
     test_details_json=$(
         find "$allure_results_dir" -maxdepth 1 -name '*-result.json' -print0 2>/dev/null |
-            xargs -0 -r jq -s '[
+            xargs -0 -r cat -- |
+            jq -s '[
               .[] | {
                 status: (
                   .status as $s |

--- a/email-notification/generate-email-notification-json.sh
+++ b/email-notification/generate-email-notification-json.sh
@@ -46,6 +46,7 @@ generate_email_notification_json() {
     # Calculate pass rate and test details
     # shellcheck source=/home/runner/work/qubership-testing-platform-common-scripts/qubership-testing-platform-common-scripts/scripts/email-notification/calculate-email-notification-variables.sh
     source "$SCRIPT_DIR/calculate-email-notification-variables.sh" "$allure_results_dir"
+    unset TEST_DETAILS_STRING
 
     # Calculate additional metrics
     if [ -n "${TEST_TOTAL_COUNT:-}" ] && [ "$TEST_TOTAL_COUNT" -gt 0 ]; then
@@ -68,104 +69,30 @@ generate_email_notification_json() {
 
     log_info "Building JSON structure..."
 
-    # Build test details JSON array
-    local test_details_json="["
-    local first_test=true
-    
-    if [ -n "${TEST_DETAILS_STRING:-}" ]; then
-        # Convert \n to actual newlines and process each test detail line
-        # Use process substitution to avoid subshell issues
-        while IFS= read -r line; do
-            # Skip header lines
-            if [[ "$line" =~ ^[[:space:]]*Status[[:space:]]*\| ]] || [[ "$line" =~ ^[[:space:]]*-+[[:space:]]*\| ]]; then
-                continue
-            fi
-            
-            # Extract status and test name from the formatted line
-            if [[ "$line" =~ ^[[:space:]]*([^|]+)\|[[:space:]]*(.+)$ ]]; then
-                local status_part="${BASH_REMATCH[1]// /}"
-                # Keep test name exactly as is (no formatting applied)
-                local test_name="${BASH_REMATCH[2]}"
-                test_name=$(printf '%s' "$test_name" | jq -R .)
-                test_name=${test_name:1:-1}
-                
-                
-                # Determine status and emoji
-                local status="UNKNOWN"
-                local emoji="❓"
-                
-                if [[ "$status_part" =~ PASSED ]]; then
-                    status="PASSED"
-                    emoji="✅"
-                elif [[ "$status_part" =~ FAILED ]]; then
-                    status="FAILED"
-                    emoji="❌"
-                elif [[ "$status_part" =~ SKIPPED ]]; then
-                    status="SKIPPED"
-                    emoji="⚠️"
-                fi
-                
-                # Add comma if not first test
-                if [ "$first_test" = true ]; then
-                    first_test=false
-                else
-                    test_details_json="$test_details_json,"
-                fi
-                
-                # Add test object to JSON array
-                test_details_json="$test_details_json"$'\n    {'$'\n      "status": "'"$status"'",'$'\n      "test_name": "'"$test_name"'",'$'\n      "emoji": "'"$emoji"'"'$'\n    }'
-            fi
-        done < <(echo -e "$TEST_DETAILS_STRING")
-    else
-        # If no test details string, try to get test details from allure results directly
-        log_info "Parsing allure results directly..."
-        
-        # Process each result file directly
-        for result_file in "$allure_results_dir"/*-result.json; do
-            if [ -f "$result_file" ]; then
-                # Extract test status and name using jq
-                local status
-                status=$(jq -r '.status' "$result_file" 2>/dev/null || echo "unknown")
-                local test_name
-                test_name=$(jq -r '.name' "$result_file" 2>/dev/null || echo "Unknown Test")
-                test_name=$(printf '%s' "$test_name" | jq -R .)
-                test_name=${test_name:1:-1}
-                
-                # Determine status and emoji
-                local emoji="❓"
-                case "$status" in
-                    "passed")
-                        status="PASSED"
-                        emoji="✅"
-                        ;;
-                    "failed")
-                        status="FAILED"
-                        emoji="❌"
-                        ;;
-                    "skipped")
-                        status="SKIPPED"
-                        emoji="⚠️"
-                        ;;
-                    *)
-                        status="UNKNOWN"
-                        emoji="❓"
-                        ;;
-                esac
-                
-                # Add comma if not first test
-                if [ "$first_test" = true ]; then
-                    first_test=false
-                else
-                    test_details_json="$test_details_json,"
-                fi
-                
-                # Add test object to JSON array
-                test_details_json="$test_details_json"$'\n    {'$'\n      "status": "'"$status"'",'$'\n      "test_name": "'"$test_name"'",'$'\n      "emoji": "'"$emoji"'"'$'\n    }'
-            fi
-        done
-    fi
-    
-    test_details_json="$test_details_json"$'\n  ]'
+    # stream test_details from allure files; never round-trip TEST_DETAILS_STRING
+    local test_details_json
+    test_details_json=$(
+        find "$allure_results_dir" -maxdepth 1 -name '*-result.json' -print0 2>/dev/null |
+            xargs -0 -r jq -s '[
+              .[] | {
+                status: (
+                  .status as $s |
+                  if $s == "passed" then "PASSED"
+                  elif $s == "failed" then "FAILED"
+                  elif $s == "skipped" then "SKIPPED"
+                  else "UNKNOWN" end
+                ),
+                test_name: .name,
+                emoji: (
+                  if .status == "passed" then "✅"
+                  elif .status == "failed" then "❌"
+                  elif .status == "skipped" then "⚠️"
+                  else "❓" end
+                )
+              }
+            ]' 2>/dev/null
+    )
+    test_details_json="${test_details_json:-[]}"
 
     # Build complete JSON structure
     local json_content='{

--- a/error-handler.sh
+++ b/error-handler.sh
@@ -48,7 +48,8 @@ finalize_once() {
       export TEST_FAILED_COUNT=0
       export TEST_SKIPPED_COUNT=0
       export TEST_COVERAGE=0
-      export TEST_DETAILS_STRING=""
+      unset TEST_DETAILS_STRING
+      export TEST_DETAILS_FILE=""
       export EXECUTION_DATE
       EXECUTION_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
       export TIMESTAMP

--- a/git-clone.sh
+++ b/git-clone.sh
@@ -96,12 +96,12 @@ clone_repository() {
     # ============================================
     # Download archive with enhanced error handling
     # - connect timeout: 30s
-    # - max time: 120s
+    # - max time: 120s (default)
     # ============================================
     HTTP_CODE="$(
         curl -sS -L \
-            --connect-timeout 30 \
-            --max-time 120 \
+            --connect-timeout "${GIT_CLONE_CONNECT_TIMEOUT:-30}" \
+            --max-time "${GIT_CLONE_MAX_TIME:-120}" \
             --fail \
             -H "PRIVATE-TOKEN: ${ATP_TESTS_GIT_TOKEN}" \
             "$ARCHIVE_URL" \

--- a/git-clone.sh
+++ b/git-clone.sh
@@ -100,8 +100,8 @@ clone_repository() {
     # ============================================
     HTTP_CODE="$(
         curl -sS -L \
-            --connect-timeout "${GIT_CLONE_CONNECT_TIMEOUT:-30}" \
-            --max-time "${GIT_CLONE_MAX_TIME:-120}" \
+            --connect-timeout "${ATP_TESTS_GIT_CLONE_CONNECT_TIMEOUT:-30}" \
+            --max-time "${ATP_TESTS_GIT_CLONE_MAX_TIME:-120}" \
             --fail \
             -H "PRIVATE-TOKEN: ${ATP_TESTS_GIT_TOKEN}" \
             "$ARCHIVE_URL" \

--- a/upload-monitor.sh
+++ b/upload-monitor.sh
@@ -119,21 +119,21 @@ finalize_upload() {
 
     # Final sync to ensure all files are captured
     if [[ "$ATP_STORAGE_PROVIDER" == "aws" ]]; then
-        s5cmd --no-verify-ssl sync "$TMP_DIR/allure-results/" "${RESULTS_S3_PATH}allure-results/"
-        s5cmd --no-verify-ssl sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH"
-        s5cmd --no-verify-ssl sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/"
+        s5cmd --no-verify-ssl sync "$TMP_DIR/allure-results/" "${RESULTS_S3_PATH}allure-results/" > /dev/null 2>&1
+        s5cmd --no-verify-ssl sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH" > /dev/null 2>&1
+        s5cmd --no-verify-ssl sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/" > /dev/null 2>&1
     elif [[ "$ATP_STORAGE_PROVIDER" == "minio" || "$ATP_STORAGE_PROVIDER" == "s3" ]]; then
-        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/allure-results/" "${RESULTS_S3_PATH}allure-results/"
-        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH"
-        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/"
+        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/allure-results/" "${RESULTS_S3_PATH}allure-results/" > /dev/null 2>&1
+        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH" > /dev/null 2>&1
+        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/" > /dev/null 2>&1
     fi
 
     # Upload marker file
     echo "${ENABLE_JIRA_INTEGRATION:-false}" > $TMP_DIR/allure-results.uploaded
     if [[ "$ATP_STORAGE_PROVIDER" == "aws" ]]; then
-        s5cmd --no-verify-ssl cp "$TMP_DIR/allure-results.uploaded" "${RESULTS_S3_PATH}allure-results.uploaded"
+        s5cmd --no-verify-ssl cp "$TMP_DIR/allure-results.uploaded" "${RESULTS_S3_PATH}allure-results.uploaded" > /dev/null 2>&1
     elif [[ "$ATP_STORAGE_PROVIDER" == "minio" || "$ATP_STORAGE_PROVIDER" == "s3" ]]; then
-        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" cp "$TMP_DIR/allure-results.uploaded" "${RESULTS_S3_PATH}allure-results.uploaded"
+        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" cp "$TMP_DIR/allure-results.uploaded" "${RESULTS_S3_PATH}allure-results.uploaded" > /dev/null 2>&1
     fi
 
     # Generate result URLs


### PR DESCRIPTION





<!-- start messages -->
### Commit messages:
[callmesi](https://github.com/Netcracker/qubership-testing-platform-common-scripts/commit/3718972849a10724821d188566e16e34dd1ed842) fix: use file instead of test_details json ENV
[callmesi](https://github.com/Netcracker/qubership-testing-platform-common-scripts/commit/76a9a2b04ed04f5fab3654154bf403911fac9d03) fix: use variable for timeout
[callmesi](https://github.com/Netcracker/qubership-testing-platform-common-scripts/commit/a16d20c2561d978a1b36e3fc653d5ae8dca960e9) fix: omit logs for cp to s3
[callmesi](https://github.com/Netcracker/qubership-testing-platform-common-scripts/commit/b17bc139f2feb27e8c64bb243e0891f5d0ec4cb0) fix: logs separation by batch []
[callmesi](https://github.com/Netcracker/qubership-testing-platform-common-scripts/commit/92b61a5f572c59df678da552d5ee06dada51db79) fix: variable name
<!-- end messages -->




